### PR TITLE
Specify python3 for apk and stop chowning all of /data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
       build-base \
       nginx \
       openssl \
-      python \
+      python3 \
       nodejs \
       nodejs-npm \
       unrar \

--- a/rootfs/usr/local/bin/entrypoint.sh
+++ b/rootfs/usr/local/bin/entrypoint.sh
@@ -21,5 +21,6 @@ set -euo pipefail
 # Remove previous session lock
 [ -r /data/.session/rtorrent.lock ] && rm -f /data/.session/rtorrent.lock
 
-chown -R $PUID:$PGID /data /config /tmp /usr/local/flood
+# Removed /data because this takes FOREVER
+chown -R $PUID:$PGID /config /tmp /usr/local/flood
 exec "${@}"


### PR DESCRIPTION
If you point /data at anything sizable, the container never truly starts because of the neverending chown command. Ownership is my responsibility as the server admin, not the container's, so I've changed it so it only chowns what is necessary. Apk was not specifying the python package correctly, causing build failures on docker hub.